### PR TITLE
feat: add built-in Substack social link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This plugin supports three web font libraries for rendering social media icons:
 1. **[FontAwesome](https://fontawesome.com/)** - A comprehensive icon library with support for brands and general symbols
 2. **[Academicons](https://jpswalsh.github.io/academicons/)** - Specialized icons for academic platforms and publications
 3. **[Scholar Icons](https://louisfacun.github.io/scholar-icons/)** - Additional icons for technical and coding platforms
+4. **Inline SVGs** - For platforms without support in the above libraries (e.g., Substack)
 
 ### Using Icons from Other Font Sources
 
@@ -18,7 +19,7 @@ While this plugin comes with built-in support for the three font libraries above
 
 ## Built-in Social Platforms
 
-The plugin includes built-in support for 53 social media and academic platforms:
+The plugin includes built-in support for 54 social media and academic platforms:
 
 ### Academic & Research Platforms
 
@@ -26,7 +27,7 @@ academia_edu, acm_id, arxiv_id, dblp_url, hal_id, ieee_id, inspirehep_id, lattes
 
 ### Social Media Platforms
 
-blogger_url, bluesky_url, discord_id, facebook_id, flickr_id, instagram_id, mastodon_username, medium_username, pinterest_id, quora_username, reddit_username, spotify_id, telegram_username, tiktok_username, tumblr_username, twitch_username, x_username, youtube_id
+blogger_url, bluesky_url, discord_id, facebook_id, flickr_id, instagram_id, mastodon_username, medium_username, pinterest_id, quora_username, reddit_username, spotify_id, substack_username, telegram_username, tiktok_username, tumblr_username, twitch_username, x_username, youtube_id
 
 ### Professional & Networking
 

--- a/lib/jekyll-socials.rb
+++ b/lib/jekyll-socials.rb
@@ -70,7 +70,12 @@ module Jekyll
       'leetcode_id' => "<i class='si si-leetcode'></i>"
     }.freeze
 
-    SOCIAL_ICONS = ACADEMICONS.merge(FONT_AWESOME).merge(SCHOLAR_ICONS)
+    # Inline SVG icons for platforms without support in the above font libraries
+    SVG_ICONS = {
+      'substack_username' => "<svg class='substack-icon' role='img' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg' aria-label='Substack' fill='currentColor'><path d='M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z'/></svg>"
+    }.freeze
+
+    SOCIAL_ICONS = ACADEMICONS.merge(FONT_AWESOME).merge(SCHOLAR_ICONS).merge(SVG_ICONS)
 
     SOCIAL_URLS = {
       'academia_edu' => "https://%s.academia.edu/%s",
@@ -121,6 +126,7 @@ module Jekyll
       'work_url' => "%s",
       'x_username' => "https://twitter.com/%s",
       'youtube_id' => "https://youtube.com/@%s",
+      'substack_username' => "https://%s.substack.com",
       'zotero_username' => "https://www.zotero.org/%s"
     }.freeze
 

--- a/site/_data/socials.yml
+++ b/site/_data/socials.yml
@@ -45,6 +45,7 @@ scholar_userid: qc6CJjYAAAAJ # your Google Scholar ID
 # spotify_id: # your spotify id
 # stackoverflow_id: # your stackoverflow id
 # strava_userid: # your strava user id
+# substack_username: # your Substack username (username.substack.com)
 # telegram_username: # your Telegram user name
 # unsplash_id: # your unsplash id
 # wechat_username: # your WeChat user name

--- a/site/_pages/example.md
+++ b/site/_pages/example.md
@@ -78,6 +78,7 @@ scholar_userid: qc6CJjYAAAAJ # your Google Scholar ID
 # spotify_id: # your spotify id
 # stackoverflow_id: # your stackoverflow id
 # strava_userid: # your strava user id
+# substack_username: # your Substack username (username.substack.com)
 # telegram_username: # your Telegram user name
 # unsplash_id: # your unsplash id
 # wechat_username: # your WeChat user name


### PR DESCRIPTION
## Summary

- Adds `substack_username` as a built-in social platform with URL template `https://%s.substack.com`
- Introduces `SVG_ICONS` hash for platforms without FontAwesome/Academicons/Scholar Icons support, using an inline SVG of the official Substack logo
- Updates README and documentation site with Substack entry

Closes #3

## Test plan

- [ ] Add `substack_username: testuser` to `site/_data/socials.yml` and verify the SVG icon renders with a link to `https://testuser.substack.com`
- [ ] Verify existing socials are unaffected
- [ ] Verify custom socials still work as expected