### PR TITLE
Allow support for simple-icons 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ build-iPhoneSimulator/
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+site/_site

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This plugin supports three web font libraries for rendering social media icons:
 2. **[Academicons](https://jpswalsh.github.io/academicons/)** - Specialized icons for academic platforms and publications
 3. **[Scholar Icons](https://louisfacun.github.io/scholar-icons/)** - Additional icons for technical and coding platforms
 
+It also supports **[Simple Icons](https://github.com/simple-icons/simple-icons/)** as SVGs. The plugin fetches the SVGs from the Simple Icons CDN at build time, saves them into your generated site, and renders them using a mask so they are fully themeable via CSS.
+
 ### Using Icons from Other Font Sources
 
 While this plugin comes with built-in support for the three font libraries above, you can use icons from any other font library you add to your site. Simply provide the icon class name in the `logo` field of a custom social or when overriding a built-in social's icon. The plugin will automatically detect whether the value is a file path (by checking for file extensions like .png, .jpg, .svg) or an icon class.
@@ -61,6 +63,46 @@ custom_social:
   logo: custom-font-icon-class # Any icon class from fonts you've added
   title: My Custom Social
   url: https://example.com
+```
+
+## Simple Icons (SVG)
+
+You can use any Simple Icons slug and the plugin will download the SVG into your generated site (default: `assets/img/social/simple-icons/`).
+Use https://simpleicons.org/ to find the slug for the icon you want to use.
+
+### Config
+
+```yml
+jekyll_socials:
+  simple_icons:
+    enabled: true
+    output_dir: assets/img/social/simple-icons
+    cdn_url: https://cdn.simpleicons.org/
+```
+
+### Usage
+
+For a custom social:
+
+```yml
+codeberg:
+  simple_icon: codeberg
+  title: Codeberg
+  url: https://codeberg.org/your_handle
+```
+
+### Themeable CSS
+
+The Simple Icons output uses `currentColor`, so you can theme them by setting color on the link:
+
+```css
+.contact-icons a {
+  color: var(--global-text-color);
+}
+
+.contact-icons a:hover {
+  color: var(--global-theme-color);
+}
 ```
 
 ## Building and Releasing a New Version

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 A plugin to help add social media info to your site. For more information, check the [documentation](https://george-gca.github.io/jekyll-socials/).
 
-## Supported Web Fonts
+## Supported Icon Libraries
 
-This plugin supports three web font libraries for rendering social media icons:
+This plugin supports four icon libraries for rendering social media icons:
 
 1. **[FontAwesome](https://fontawesome.com/)** - A comprehensive icon library with support for brands and general symbols
 2. **[Academicons](https://jpswalsh.github.io/academicons/)** - Specialized icons for academic platforms and publications
 3. **[Scholar Icons](https://louisfacun.github.io/scholar-icons/)** - Additional icons for technical and coding platforms
-4. **[Simple Icons](https://github.com/simple-icons/simple-icons/)** - A collection of popular brand icons as SVGs
+4. **[Simple Icons](https://github.com/simple-icons/simple-icons/)** - A collection of popular brand icons as SVGs, fetched at build time
 
 ### Using Icons from Other Font Sources
 
@@ -110,6 +110,45 @@ custom_social:
   logo: custom-font-icon-class # Any icon class from fonts you've added
   title: My Custom Social
   url: https://example.com
+```
+
+### Simple Icons (SVG)
+
+For any icon available on [Simple Icons](https://simpleicons.org/), use the `simple_icon` field with the icon's slug. The plugin fetches the SVG from the Simple Icons CDN at build time and saves it into `assets/img/social/simple-icons/` in your generated site.
+
+```yml
+codeberg:
+  simple_icon: codeberg
+  title: Codeberg
+  url: https://codeberg.org/your_handle
+```
+
+The rendered icon uses a CSS mask, so you theme it via the `color` property:
+
+```scss
+.contact-icons {
+  .simple-icon {
+    display: inline-block;
+    width: 3.2rem;
+    height: 3.2rem;
+    background-color: currentColor;
+    -webkit-mask: var(--social-icon-mask) no-repeat center / contain;
+    mask: var(--social-icon-mask) no-repeat center / contain;
+    color: #ddd;
+    &:hover {
+      color: green;
+    }
+  }
+}
+```
+
+You can configure Simple Icons behavior in `_config.yml`:
+
+```yml
+jekyll_socials:
+  simple_icons:
+    enabled: true                              # set to false to disable SVG downloading (default: true)
+    cdn_url: https://simpleicons.org/icons/    # CDN base URL for fetching SVG files
 ```
 
 ## Building and Releasing a New Version

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ This plugin supports three web font libraries for rendering social media icons:
 1. **[FontAwesome](https://fontawesome.com/)** - A comprehensive icon library with support for brands and general symbols
 2. **[Academicons](https://jpswalsh.github.io/academicons/)** - Specialized icons for academic platforms and publications
 3. **[Scholar Icons](https://louisfacun.github.io/scholar-icons/)** - Additional icons for technical and coding platforms
-
-It also supports **[Simple Icons](https://github.com/simple-icons/simple-icons/)** as SVGs. The plugin fetches the SVGs from the Simple Icons CDN at build time, saves them into your generated site, and renders them using a mask so they are fully themeable via CSS.
+4. **[Simple Icons](https://github.com/simple-icons/simple-icons/)** - A collection of popular brand icons as SVGs
 
 ### Using Icons from Other Font Sources
 
@@ -65,46 +64,6 @@ custom_social:
   url: https://example.com
 ```
 
-## Simple Icons (SVG)
-
-You can use any Simple Icons slug and the plugin will download the SVG into your generated site (default: `assets/img/social/simple-icons/`).
-Use https://simpleicons.org/ to find the slug for the icon you want to use.
-
-### Config
-
-```yml
-jekyll_socials:
-  simple_icons:
-    enabled: true
-    output_dir: assets/img/social/simple-icons
-    cdn_url: https://cdn.simpleicons.org/
-```
-
-### Usage
-
-For a custom social:
-
-```yml
-codeberg:
-  simple_icon: codeberg
-  title: Codeberg
-  url: https://codeberg.org/your_handle
-```
-
-### Themeable CSS
-
-The Simple Icons output uses `currentColor`, so you can theme them by setting color on the link:
-
-```css
-.contact-icons a {
-  color: var(--global-text-color);
-}
-
-.contact-icons a:hover {
-  color: var(--global-theme-color);
-}
-```
-
 ## Building and Releasing a New Version
 
 To build and release a new gem version:
@@ -116,6 +75,7 @@ To build and release a new gem version:
    ```
 
 2. **Push to RubyGems** - This publishes the gem to [RubyGems.org](https://rubygems.org/), making it available for installation:
+
    ```bash
    gem push jekyll-socials-X.X.X.gem
    ```

--- a/lib/jekyll-socials.rb
+++ b/lib/jekyll-socials.rb
@@ -10,7 +10,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
   next unless enabled
 
   output_dir = (simple_icons_cfg["output_dir"] || "assets/img/social/simple-icons").sub(%r{\A/}, "")
-  cdn_url = (simple_icons_cfg["cdn_url"] || "https://cdn.simpleicons.org/")
+  cdn_url = (simple_icons_cfg["cdn_url"] || "https://simpleicons.org/icons/")
   cdn_url = cdn_url.end_with?("/") ? cdn_url : "#{cdn_url}/"
 
   socials = site.data["socials"] || {}
@@ -31,7 +31,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
     dest_path = File.join(dest_base, "#{normalized}.svg")
     next if File.exist?(dest_path)
     begin
-      uri = URI.parse("#{cdn_url}#{normalized}")
+      uri = URI.parse("#{cdn_url}#{normalized}.svg")
       response = Net::HTTP.get_response(uri)
       if response.is_a?(Net::HTTPSuccess) && !response.body.to_s.empty?
         File.write(dest_path, response.body)

--- a/lib/jekyll-socials.rb
+++ b/lib/jekyll-socials.rb
@@ -47,16 +47,20 @@ end
 
 module Jekyll
   class SocialLinksTag < Liquid::Tag
-        def render_simple_icon_link(simple_icon_slug, social, context)
-          return '' if simple_icon_slug.nil? || simple_icon_slug.to_s.strip.empty?
-          slug = simple_icon_slug.to_s.strip.downcase.gsub(/[^a-z0-9\-]/, "")
-          output_dir = "assets/img/social/simple-icons"
-          icon_url = relative_url("/#{output_dir}/#{slug}.svg", context)
-          icon_html = "<span class='simple-icon simple-icon--#{slug}' style='--social-icon-mask:url(#{icon_url});'></span>"
-          url = social[1]['url']
-          title = social[1]['title'] || slug.capitalize
-          "<a href='#{url}' title='#{title}'>#{icon_html}</a>"
-        end
+    def render_simple_icon_link(simple_icon_slug, social, context)
+      return '' if simple_icon_slug.nil? || simple_icon_slug.to_s.strip.empty?
+
+      site = context.registers[:site]
+      cfg = site.config.dig('jekyll_socials', 'simple_icons') || {}
+      output_dir = (cfg['output_dir'] || 'assets/img/social/simple-icons').sub(%r{\A/}, '')
+      slug = simple_icon_slug.to_s.strip.downcase.gsub(/[^a-z0-9-]/, '')
+      icon_url = relative_url("/#{output_dir}/#{slug}.svg", context)
+      icon_html = "<span class='simple-icon simple-icon--#{slug}' style='--social-icon-mask:url(#{icon_url});'></span>"
+      url = social[1]['url']
+      title = social[1]['title'] || slug.capitalize
+      "<a href='#{url}' title='#{title}'>#{icon_html}</a>"
+    end
+
     # Helper method to construct relative URL with baseurl
     def relative_url(path, context)
       return path if path.include?('://')

--- a/site/_data/socials.yml
+++ b/site/_data/socials.yml
@@ -55,6 +55,14 @@ scholar_userid: qc6CJjYAAAAJ # your Google Scholar ID
 # x_username: # your X handle
 # youtube_id: # your youtube channel id (youtube.com/@<youtube_id>)
 # zotero_username: # your zotero username
+codeberg:
+  simple_icon: codeberg
+  title: Codeberg
+  url: https://codeberg.org/
+ruby:
+  simple_icon: ruby
+  title: Ruby
+  url: https://www.ruby-lang.org/en/
 custom_social: # can be any name here other than the ones already defined above
   # logo can be a link to an image (png, jpg, svg)
   # or an Academicons class like "ai ai-acm"

--- a/site/_pages/example.md
+++ b/site/_pages/example.md
@@ -10,6 +10,7 @@ This is a Jekyll plugin that adds social links to your site. It fetches social i
 - [Academicons](https://jpswalsh.github.io/academicons/)
 - [Font Awesome](https://fontawesome.com/)
 - [Scholar Icons](https://github.com/louisfacun/scholar-icons)
+- [Simple Icons (SVG)](https://github.com/simple-icons/simple-icons)
 
 ## Installation
 
@@ -88,6 +89,10 @@ scholar_userid: qc6CJjYAAAAJ # your Google Scholar ID
 # x_username: # your X handle
 # youtube_id: # your youtube channel id (youtube.com/@<youtube_id>)
 # zotero_username: # your zotero username
+codeberg:
+  simple_icon: codeberg
+  title: Codeberg
+  url: https://codeberg.org/
 custom_social: # can be any name here other than the ones already defined above
   # logo can be a link to an image (png, jpg, svg)
   # or an Academicons class like "ai ai-acm"
@@ -122,6 +127,29 @@ custom_social:
   url: https://example.com
 ```
 
+### Simple Icons (SVG)
+
+You can use any [Simple Icons](https://simpleicons.org/) slug and the plugin will fetch the SVG from the Simple Icons CDN, saving it into your generated site (default: `assets/img/social/simple-icons/`).
+
+```yml
+codeberg:
+  simple_icon: codeberg
+  title: Codeberg
+  url: https://codeberg.org/your_handle
+```
+
+Theme with CSS by changing link color:
+
+```css
+.contact-icons a {
+  color: #ddd;
+}
+
+.contact-icons a:hover {
+  color: green;
+}
+```
+
 Next, add the following to your layout file:
 
 {% raw %}
@@ -147,6 +175,19 @@ Now, let's stylize the social icons. To do this, add this to your CSS file:
       img {
         width: 3.2rem;
         height: 3.2rem;
+      }
+
+      .simple-icon {
+        display: inline-block;
+        width: 3.2rem;
+        height: 3.2rem;
+        background-color: #ddd;
+        -webkit-mask: var(--social-icon-mask) no-repeat center / contain;
+        mask: var(--social-icon-mask) no-repeat center / contain;
+        color: #{$text-color};
+        &:hover {
+          color: green;
+        }
       }
 
       svg {

--- a/site/_pages/example.md
+++ b/site/_pages/example.md
@@ -138,15 +138,16 @@ codeberg:
   url: https://codeberg.org/your_handle
 ```
 
-Theme with CSS by changing link color:
+Theme the icon color with SCSS:
 
-```css
-.contact-icons a {
-  color: #ddd;
-}
-
-.contact-icons a:hover {
-  color: green;
+```scss
+.contact-icons {
+  .simple-icon {
+    color: #ddd;
+    &:hover {
+      color: green;
+    }
+  }
 }
 ```
 
@@ -162,9 +163,9 @@ Next, add the following to your layout file:
 
 {% endraw %}
 
-Now, let's stylize the social icons. To do this, add this to your CSS file:
+Now, let's stylize the social icons. To do this, add this to your SCSS file:
 
-```css
+```scss
 .social {
   text-align: center;
 
@@ -181,7 +182,7 @@ Now, let's stylize the social icons. To do this, add this to your CSS file:
         display: inline-block;
         width: 3.2rem;
         height: 3.2rem;
-        background-color: #ddd;
+        background-color: currentColor;
         -webkit-mask: var(--social-icon-mask) no-repeat center / contain;
         mask: var(--social-icon-mask) no-repeat center / contain;
         color: #{$text-color};

--- a/site/_sass/main.scss
+++ b/site/_sass/main.scss
@@ -46,6 +46,20 @@ code {
         height: 3.2rem;
       }
 
+
+      .simple-icon {
+        display: inline-block;
+        width: 3.2rem;
+        height: 3.2rem;
+        background-color: currentColor;
+        -webkit-mask: var(--social-icon-mask) no-repeat center / contain;
+        mask: var(--social-icon-mask) no-repeat center / contain;
+        color: #{$text-color};
+        &:hover {
+          color: green;
+        }
+      }
+
       svg {
         width: 3.5rem;
         height: 4rem;


### PR DESCRIPTION
Resolve #7 

<img width="2928" height="1000" alt="image" src="https://github.com/user-attachments/assets/e7d23ef8-be5c-4717-bc9d-7bfc66dad869" />


This pull request adds support for Simple Icons (SVG) to the Jekyll Socials plugin, enabling users to include any Simple Icon in their site. The plugin fetches SVGs from the Simple Icons CDN at build time, stores them in the generated site, and renders them as themeable icons using CSS masks. The documentation and example files have been updated to reflect this new feature, and sample usage has been provided.

**Simple Icons (SVG) Support:**

* Added a post-write hook in `lib/jekyll-socials.rb` to download Simple Icons SVGs from the CDN and save them into the site output directory (`assets/img/social/simple-icons`). This hook detects which icons are needed based on the `simple_icon` field in `socials.yml` and fetches them automatically.
* Updated the rendering logic in `SocialLinksTag` to support the `simple_icon` field, generating themeable links using SVG masks and `currentColor` for easy CSS customization.

**Documentation and Examples:**

* Expanded `README.md` with instructions, configuration, and usage examples for Simple Icons, including how to theme them with CSS.
* Updated `site/_pages/example.md` and `site/_data/socials.yml` to demonstrate Simple Icons usage, configuration, and theming with CSS.
* Enhanced example and main CSS files to show how to theme Simple Icons using link color and hover effects.

**In Production Example**
See https://github.com/dfuchss/fuchss.org/blob/bbce75e23cd4a6175d26d53f43620f15ec3fc3fd/_data/socials.yml#L12-L15 as an example on how that works.